### PR TITLE
repeat in usefulness_name added

### DIFF
--- a/scripts/hovig_project 3_data 607.Rmd
+++ b/scripts/hovig_project 3_data 607.Rmd
@@ -58,7 +58,7 @@ for(i in 3:length(tidy.data)){
 }
 
 total_usefulness<-data.frame(
-  usefulness_name=c("notuseful","veryuseful","somewhatuseful"),
+  usefulness_name=c(rep("notuseful",18),rep("veryuseful",18),rep("somewhatuseful",18)),
   usefulness_count=c(total_notuseful,total_veryuseful,total_somewhatuseful)
   )
 


### PR DESCRIPTION
somehow the indexing between usefulness_name and usefulness_count in total_usefulness data frame is not done consecutively like: notuseful to total_notuseful, veryuseful to total_veryuseful and somewhatuseful to total_somewhatuseful. But instead using repeat will help us keeping values to the right index as per Justin's suggestion.